### PR TITLE
Remove zero value return and return nil pointer in Pipe.Invoke (fixes #13)

### DIFF
--- a/examples/pipe/markdown/main.go
+++ b/examples/pipe/markdown/main.go
@@ -44,7 +44,7 @@ func main() {
 	pipe := pipe.New(messages, ollamaClient, parser)
 	result, _ := pipe.Invoke(ctx)
 
-	for heading, content := range result {
+	for heading, content := range *result {
 		// Do something with the sections. E.g. let other agents validate the content.
 		fmt.Printf("\n--- %s ---\n%s\n", heading, content)
 	}

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -21,20 +21,18 @@ func New[T any](messages []llm.Message, model llm.LLM, outputParser output.Parse
 	}
 }
 
-func (p *Pipe[T]) Invoke(ctx context.Context) (T, error) {
+func (p *Pipe[T]) Invoke(ctx context.Context) (*T, error) {
 	formatInstructions := p.OutputParser.GetFormatInstructions()
 	p.Messages[0].Content += " " + formatInstructions
 
 	output, err := p.Model.GenerateContent(ctx, p.Messages)
 	if err != nil {
-		var zero T
-		return zero, err
+		return nil, err
 	}
 
 	parsedOutput, err := p.OutputParser.Parse(output.Result)
 	if err != nil {
-		var zero T
-		return zero, err
+		return nil, err
 	}
-	return parsedOutput, nil
+	return &parsedOutput, nil
 }


### PR DESCRIPTION
## Summary

This PR addresses issue #13 by removing the use of a zero value variable of type `T` in the `Invoke` method of the `Pipe` struct and instead returning `nil` when an error occurs.

## Changes

- Changed the return type of `Invoke` from `(T, error)` to `(*T, error)`.
- Removed:
  ```go
  var zero T
  return zero, err

- Replaced with:
 ```go
return nil, err
```
- Adjusted the successful return to return a pointer to T:
 ```go
return &parsedOutput, nil
```
- Updated all call sites (including main.go) to properly handle the pointer return type.

@TobiasGleiter 