### PR TITLE
refactor:replace interface{} with any

### DIFF
--- a/examples/llm/openai/main.go
+++ b/examples/llm/openai/main.go
@@ -18,7 +18,7 @@ func main() {
 		{Role: "user", Content: "{{.text}}"},
 	})
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"inputLanguage":  "English",
 		"outputLanguage": "French",
 		"text":           "I love programming.",

--- a/input/chat/chat_templates.go
+++ b/input/chat/chat_templates.go
@@ -15,7 +15,7 @@ func New(messages []llm.Message) (*PromptTemplate, error) {
 	return &PromptTemplate{Messages: messages}, nil
 }
 
-func (cpt *PromptTemplate) Format(data interface{}) ([]llm.Message, error) {
+func (cpt *PromptTemplate) Format(data any) ([]llm.Message, error) {
 	var formattedMessages []llm.Message
 
 	for _, templat := range cpt.Messages {

--- a/input/chat/chat_templates_test.go
+++ b/input/chat/chat_templates_test.go
@@ -36,7 +36,7 @@ func TestChatPromptTemplateFormatMessages(t *testing.T) {
 		t.Fatalf("unexpected error creating chat prompt template: %v", err)
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"inputLanguage":  "English",
 		"outputLanguage": "French",
 		"text":           "I love programming.",

--- a/input/prompt/prompt_templates.go
+++ b/input/prompt/prompt_templates.go
@@ -21,7 +21,7 @@ func New(templateString string) (*Template, error) {
 	return &Template{Template: tmpl}, nil
 }
 
-func (pt *Template) Format(data interface{}) (string, error) {
+func (pt *Template) Format(data any) (string, error) {
 	var promptBuffer bytes.Buffer
 	err := pt.Template.Execute(&promptBuffer, data)
 	if err != nil {

--- a/input/prompt/prompt_templates_test.go
+++ b/input/prompt/prompt_templates_test.go
@@ -45,7 +45,7 @@ func TestFormat(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		data       interface{}
+		data       any
 		want       string
 		shouldFail bool
 	}{

--- a/llm/openai/openai_types.go
+++ b/llm/openai/openai_types.go
@@ -34,9 +34,9 @@ type ChoiceResponse struct {
 		Role    string `json:"role"`
 		Content string `json:"content"`
 	} `json:"message"`
-	Logprobs     interface{} `json:"logprobs"`
-	FinishReason string      `json:"finish_reason"`
-	Index        int         `json:"index"`
+	Logprobs     any    `json:"logprobs"`
+	FinishReason string `json:"finish_reason"`
+	Index        int    `json:"index"`
 }
 
 type UsageResponse struct {


### PR DESCRIPTION
Summary
Replaces all occurrences of `interface{}` with `any` to follow modern Go conventions.
 Changes
- Updated 6 files to use `any` instead of `interface{}`
 Related Issue
#15